### PR TITLE
Adding 'djangae.contrib.security' to `INSTALLED_APPS` so that the tests ...

### DIFF
--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'djangae.contrib.gauth',
+    'djangae.contrib.security',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',


### PR DESCRIPTION
...are run.

Tests for this app have been added in https://github.com/potatolondon/djangae/pull/129.